### PR TITLE
Fix linking errors when including flags.h in more than one cpp file

### DIFF
--- a/include/flags.h
+++ b/include/flags.h
@@ -102,13 +102,13 @@ std::optional<T> get(const argument_map& options,
 
 // Since the values are already stored as strings, there's no need to use `>>`.
 template <>
-std::optional<std::string_view> get(const argument_map& options,
+inline std::optional<std::string_view> get(const argument_map& options,
                                     const std::string_view& option) {
   return get_value(options, option);
 }
 
 template <>
-std::optional<std::string> get(const argument_map& options,
+inline std::optional<std::string> get(const argument_map& options,
                                const std::string_view& option) {
   if (const auto view = get<std::string_view>(options, option)) {
     return std::string(*view);
@@ -121,7 +121,7 @@ std::optional<std::string> get(const argument_map& options,
 // present.
 constexpr std::array<const char*, 5> falsities{{"0", "n", "no", "f", "false"}};
 template <>
-std::optional<bool> get(const argument_map& options,
+inline std::optional<bool> get(const argument_map& options,
                         const std::string_view& option) {
   if (const auto value = get_value(options, option)) {
     return std::none_of(falsities.begin(), falsities.end(),
@@ -148,7 +148,7 @@ std::optional<T> get(const std::vector<std::string_view>& positional_arguments,
 
 // Since the values are already stored as strings, there's no need to use `>>`.
 template <>
-std::optional<std::string_view> get(
+inline std::optional<std::string_view> get(
     const std::vector<std::string_view>& positional_arguments,
     size_t positional_index) {
   if (positional_index < positional_arguments.size()) {
@@ -158,7 +158,7 @@ std::optional<std::string_view> get(
 }
 
 template <>
-std::optional<std::string> get(
+inline std::optional<std::string> get(
     const std::vector<std::string_view>& positional_arguments,
     size_t positional_index) {
   if (positional_index < positional_arguments.size()) {


### PR DESCRIPTION
The template specialization methods must be explicitly marked with inline, otherwise including flags.h twice will cause linker errors.

`
Error	LNK2005	"class std::optional<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > > __cdecl flags::detail::get<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > >(class std::unordered_map<class std::basic_string_view<char,struct std::char_traits<char> >,class std::optional<class std::basic_string_view<char,struct std::char_traits<char> > >,struct std::hash<class std::basic_string_view<char,struct std::char_traits<char> > >,struct std::equal_to<class std::basic_string_view<char,struct std::char_traits<char> > >,class std::allocator<struct std::pair<class std::basic_string_view<char,struct std::char_traits<char> > const ,class std::optional<class std::basic_string_view<char,struct std::char_traits<char> > > > > > const &,class std::basic_string_view<char,struct std::char_traits<char> > const &)" (??$get@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@detail@flags@@YA?AV?$optional@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@std@@AEBV?$unordered_map@V?$basic_string_view@DU?$char_traits@D@std@@@std@@V?$optional@V?$basic_string_view@DU?$char_traits@D@std@@@std@@@2@U?$hash@V?$basic_string_view@DU?$char_traits@D@std@@@std@@@2@U?$equal_to@V?$basic_string_view@DU?$char_traits@D@std@@@std@@@2@V?$allocator@U?$pair@$$CBV?$basic_string_view@DU?$char_traits@D@std@@@std@@V?$optional@V?$basic_string_view@DU?$char_traits@D@std@@@std@@@2@@std@@@2@@3@AEBV?$basic_string_view@DU?$char_traits@D@std@@@3@@Z) already defined in app.game-d.lib(appmain.obj)	app.entry	E:\repo\glmovement\.build\projects\app.game-d.lib(rendersystem.obj)	1	
`